### PR TITLE
Revert "Fix `info` parameter not appearing in autograding failure messages"

### DIFF
--- a/.github/workflows/classroom.yml
+++ b/.github/workflows/classroom.yml
@@ -381,32 +381,18 @@ jobs:
               if (i <= length(tap_lines) && trimws(tap_lines[i]) == '---') {
                 i <- i + 1L
                 while (i <= length(tap_lines) && trimws(tap_lines[i]) != '...') {
-                  msg_lines <- c(msg_lines, tap_lines[i])
+                  msg_lines <- c(msg_lines, trimws(tap_lines[i]))
                   i <- i + 1L
                 }
                 i <- i + 1L
               }
-              msg_idx <- grep('^[[:space:]]*message:', msg_lines)
+              msg_idx <- grep('^message:', msg_lines)
               detail <- if (length(msg_idx) > 0) {
-                raw <- sub('^[[:space:]]*message:[[:space:]]*', '', msg_lines[msg_idx[1]])
-                if (grepl('^\\|', trimws(raw))) {
-                  raw <- ''
-                  j <- msg_idx[1] + 1L
-                  while (j <= length(msg_lines) &&
-                         !grepl('^  [^[:space:]]', msg_lines[j])) {
-                    content <- trimws(msg_lines[j])
-                    if (nchar(content) > 0) {
-                      raw <- if (nchar(raw) == 0) content else paste0(raw, ' ', content)
-                    }
-                    j <- j + 1L
-                  }
-                } else {
-                  j <- msg_idx[1] + 1L
-                  while (j <= length(msg_lines) &&
-                         !grepl('^  [^[:space:]]', msg_lines[j])) {
-                    raw <- paste0(raw, ' ', trimws(msg_lines[j]))
-                    j <- j + 1L
-                  }
+                raw <- sub('^message:[[:space:]]*', '', msg_lines[msg_idx[1]])
+                j <- msg_idx[1] + 1L
+                while (j <= length(msg_lines) && grepl('^  ', msg_lines[j])) {
+                  raw <- paste0(raw, ' ', trimws(msg_lines[j]))
+                  j <- j + 1L
                 }
                 raw
               } else ''


### PR DESCRIPTION
Reverts DataScience4Psych/actions#18 ── Attaching core tidyverse packages ──────────────────────── tidyverse 2.0.0 ──
✔ dplyr     1.2.0     ✔ readr     2.2.0
✔ forcats   1.0.1     ✔ stringr   1.6.0
✔ ggplot2   4.0.2     ✔ tibble    3.3.1
✔ lubridate 1.9.5     ✔ tidyr     1.3.2
✔ purrr     1.2.1     
── Conflicts ────────────────────────────────────────── tidyverse_conflicts() ──
✖ dplyr::filter() masks stats::filter()
✖ dplyr::lag()    masks stats::lag()
ℹ Use the conflicted package (<http://conflicted.r-lib.org/>) to force all conflicts to become errors

Attaching package: ‘MASS’

The following object is masked from ‘package:dplyr’:

    select

Loading required package: viridisLite

Attaching package: ‘testthat’

The following objects are masked from ‘package:readr’:

    edition_get, local_edition

Error: Error: '\|' is an unrecognized escape in character string (<input>:26:22)
Execution halted
Error: Tests failed to run (R error before metrics were written)